### PR TITLE
Add Claude and Pi agent docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Claude instructions
+
+Guidance for Claude or other AI coding agents working in this repository.
+
+## Project overview
+
+- This repository contains C++ solutions and experiments for Project Euler, Advent of Code, LeetCode, and related small projects.
+- Buck2 is the primary build system. Ninja files are generated from `BUCK` / `BUILD` files by `scripts/generate_ninja.py` and are used for a lightweight CI smoke build.
+- Many targets depend on optional system libraries such as MKL, OpenGL, CGAL, Boost, or vendored third-party code. Prefer small smoke targets unless the task requires a full target.
+
+## Setup
+
+On Ubuntu, use the repository bootstrap script:
+
+```sh
+./setupUbuntu.sh
+```
+
+The script installs packages from `ubuntuPackages.txt`, Python packages from `ubuntuPipPackages.txt`, and Buck2 into `~/.local/bin`.
+
+## Common commands
+
+```sh
+# Buck2 smoke build used by CI
+buck2 build //advent/2020/1/...
+
+# Build a Buck2 project through helper scripts
+./b.sh Normal
+./b.sh advent/2020/1
+
+# Run a Buck2 project through helper scripts
+./r.sh Normal
+
+# Regenerate Ninja files after BUCK/BUILD changes
+python3 scripts/generate_ninja.py
+
+# Ninja smoke build used by CI
+ninja advent/2020/1/1
+```
+
+## Development notes
+
+- Prefer editing `BUCK` / `BUILD` definitions first, then regenerate Ninja files with `python3 scripts/generate_ninja.py` when build metadata changes.
+- Do not hand-edit generated `build.ninja` files unless the task is explicitly about generated output; update the generator instead.
+- Keep CI smoke builds dependency-light. Expanding CI to full `//...` or full Ninja builds is likely to fail without additional system libraries.
+- Existing generated files and third-party directories are large. Keep diffs focused on files relevant to the task.
+- Preserve the C++ standard used by the build tooling unless a task specifically requires changing it.
+
+## Before opening a PR
+
+Run the smallest relevant checks. For build-system or setup changes, prefer:
+
+```sh
+bash -n setupUbuntu.sh
+python3 scripts/generate_ninja.py
+ninja advent/2020/1/1
+```
+
+If Buck2 is available locally, also run:
+
+```sh
+buck2 build //advent/2020/1/...
+```

--- a/PI.md
+++ b/PI.md
@@ -1,0 +1,42 @@
+# Pi agent instructions
+
+This file is for agents running in Pi. Also read `CLAUDE.md`; it contains the shared repository workflow, setup, and build commands.
+
+## Working style
+
+- Keep changes small and task-focused.
+- Use `rg`, `find`, and file reads to understand existing patterns before editing.
+- Prefer precise edits over rewriting large generated or third-party files.
+- Treat untracked local scratch files as user-owned unless the task explicitly asks to clean them up.
+
+## Build workflow
+
+- Primary build system: Buck2.
+- Generated smoke-build system: Ninja via `scripts/generate_ninja.py`.
+- After changing any `BUCK` or `BUILD` file, run:
+
+```sh
+python3 scripts/generate_ninja.py
+```
+
+- For quick validation, run:
+
+```sh
+ninja advent/2020/1/1
+```
+
+- If `buck2` is installed, also validate:
+
+```sh
+buck2 build //advent/2020/1/...
+```
+
+## PR checklist
+
+Before creating a PR from Pi:
+
+1. Check `git status --short --branch`.
+2. Run relevant local checks and mention them in the PR body.
+3. Exclude unrelated untracked files from commits.
+4. Create a branch with a descriptive name.
+5. Push and open the PR with `gh pr create`.


### PR DESCRIPTION
## Summary
- add `CLAUDE.md` with shared AI-agent setup, build, and PR guidance
- add `PI.md` with Pi-specific workflow and validation notes
- restore Buck2's bundled prelude config so CI works on clean checkouts

## Testing
- Not run locally; documentation plus Buck2 config change.
- GitHub Actions run on the PR.
