### PR TITLE
Fix Buck2 CSV header dependency

### DIFF
--- a/lib/io/BUCK
+++ b/lib/io/BUCK
@@ -94,6 +94,7 @@ cxx_library(
   deps=[
     "//lib:exception",
     "//lib:header",
+    "//lib:noncopyable",
     "//lib/io:stream",
     "//lib:string",
   ],


### PR DESCRIPTION
## Summary
- add the missing `//lib:noncopyable` Buck2 dependency to `//lib/io:csv`
- fixes the ETFModeling Buck2 CI failure where `csv.cpp` includes `stream.h` -> `fileIo.h` -> `lib/noncopyable.h`

## Testing
- GitHub Actions Buck2 workflow will validate `./bETFModelingBuck2.sh`
