### PR TITLE
Export Buck2 public header dependencies

### DIFF
--- a/lib/BUCK
+++ b/lib/BUCK
@@ -53,6 +53,9 @@ cxx_library(
     exported_headers=[
         "matrix.h",
     ],
+    exported_deps=[
+        ":header",
+    ],
     srcs=[
         "matrix.cpp",
     ],
@@ -68,6 +71,10 @@ cxx_library(
     name="string",
     exported_headers=[
         "string.h",
+    ],
+    exported_deps=[
+        ":exception",
+        ":header",
     ],
     srcs=[
         "string.cpp",
@@ -216,6 +223,9 @@ cxx_library(
     exported_headers=[
         "timer.h",
     ],
+    exported_deps=[
+        ":header",
+    ],
     deps=[
         ":header",
     ],
@@ -309,6 +319,9 @@ cxx_library(
     ],
     exported_headers=[
         "exception.h",
+    ],
+    exported_deps=[
+        ":header",
     ],
     deps=[
         ":header",
@@ -409,6 +422,9 @@ cxx_library(
     name="stat",
     exported_headers=[
         "stat.h",
+    ],
+    exported_deps=[
+        ":header",
     ],
     deps=[
         ":header",

--- a/lib/io/BUCK
+++ b/lib/io/BUCK
@@ -162,6 +162,8 @@ cxx_library(
   deps=[
     ":fileIo",
     "//lib:exception",
+    "//lib:header",
+    "//lib:noncopyable",
   ],
   visibility=[
     "PUBLIC",

--- a/lib/io/BUCK
+++ b/lib/io/BUCK
@@ -19,6 +19,10 @@ cxx_library(
   exported_headers=[
     "fileIo.h",
   ],
+  exported_deps=[
+    "//lib:header",
+    "//lib:noncopyable",
+  ],
   srcs=[
     "fileIo.cpp",
   ],
@@ -88,6 +92,9 @@ cxx_library(
   exported_headers=[
     "csv.h",
   ],
+  exported_deps=[
+    "//lib:header",
+  ],
   srcs=[
     "csv.cpp",
   ],
@@ -155,6 +162,9 @@ cxx_library(
   name="stream",
   exported_headers=[
     "stream.h",
+  ],
+  exported_deps=[
+    ":fileIo",
   ],
   srcs=[
     "stream.cpp",

--- a/lib/ml/BUCK
+++ b/lib/ml/BUCK
@@ -72,6 +72,11 @@ cxx_library(
   exported_headers=[
     "dataframe.h",
   ],
+  exported_deps=[
+    "//lib:exception",
+    "//lib:header",
+    "//lib:string",
+  ],
   srcs=[
     "dataframe.cpp",
   ],


### PR DESCRIPTION
## Summary
- export Buck2 deps for public headers that include other project headers
- keep direct `stream`/`csv` deps needed while compiling those targets
- continues fixing the ETFModeling Buck2 build introduced by the Buck2 migration

## Testing
- `bash -n cCommon.sh bETFModelingBuck2.sh installBuck2Ubuntu.sh installBuck2MacOS.sh setupUbuntu.sh`
- GitHub Actions Buck2 workflow will validate `./bETFModelingBuck2.sh`
