### PR TITLE
Fix ETFModeling Buck2 link deps

### DIFF
--- a/ETFModeling/BUCK
+++ b/ETFModeling/BUCK
@@ -13,6 +13,8 @@ cxx_binary(
     "//lib:random",
     "//lib:stat",
     "//lib:timer",
+    "//lib:file",
+    "//lib/io:csv",
     "//lib/ml:dataframe",
   ],
 )


### PR DESCRIPTION
## Summary
- add direct `//lib:file` and `//lib/io:csv` deps to `//ETFModeling:ETFModeling`
- fixes Buck2 executable linking after `dataframe` is linked as a shared object

## Testing
- GitHub Actions Buck2 workflow will validate `./bETFModelingBuck2.sh`
