### PR TITLE
Document Bazel build option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 buck-out/
 build-ninja/
+bazel-*
 common/common.pyc
 perf.data
 perf.data.old

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Guidance for Claude or other AI coding agents working in this repository.
 ## Project overview
 
 - This repository contains C++ solutions and experiments for Project Euler, Advent of Code, LeetCode, and related small projects.
-- Buck2 is the primary build system. Ninja files are generated from `BUCK` / `BUILD` files by `scripts/generate_ninja.py` and are used for a lightweight CI smoke build.
+- Buck2 is the primary build system. Ninja files are generated from `BUCK` / `BUILD` files by `scripts/generate_ninja.py` and are used for a lightweight CI smoke build. Bazel metadata also exists for targets that have `BUILD` files.
 - Many targets depend on optional system libraries such as MKL, OpenGL, CGAL, Boost, or vendored third-party code. Prefer small smoke targets unless the task requires a full target.
 
 ## Setup
@@ -36,11 +36,14 @@ python3 scripts/generate_ninja.py
 
 # Ninja smoke build used by CI
 ninja advent/2020/1/1
+
+# Bazel target build for packages with BUILD files
+./bBazel.sh //advent/2024/1:all
 ```
 
 ## Development notes
 
-- Prefer editing `BUCK` / `BUILD` definitions first, then regenerate Ninja files with `python3 scripts/generate_ninja.py` when build metadata changes.
+- Prefer editing `BUCK` / `BUILD` definitions first, then regenerate Ninja files with `python3 scripts/generate_ninja.py` when Ninja build metadata changes. Remember that `BUILD` files may be consumed by Bazel too.
 - Do not hand-edit generated `build.ninja` files unless the task is explicitly about generated output; update the generator instead.
 - Keep CI smoke builds dependency-light. Expanding CI to full `//...` or full Ninja builds is likely to fail without additional system libraries.
 - Existing generated files and third-party directories are large. Keep diffs focused on files relevant to the task.

--- a/PI.md
+++ b/PI.md
@@ -13,6 +13,7 @@ This file is for agents running in Pi. Also read `CLAUDE.md`; it contains the sh
 
 - Primary build system: Buck2.
 - Generated smoke-build system: Ninja via `scripts/generate_ninja.py`.
+- Additional build system: Bazel for packages that already have `BUILD` files.
 - After changing any `BUCK` or `BUILD` file, run:
 
 ```sh
@@ -23,6 +24,12 @@ python3 scripts/generate_ninja.py
 
 ```sh
 ninja advent/2020/1/1
+```
+
+- For Bazel changes, validate an explicit target, for example:
+
+```sh
+./bBazel.sh //advent/2024/1:all
 ```
 
 - If `buck2` is installed, also validate:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 projecteuler.net problems solutions.
 
-We use [Buck2](https://buck2.build/) as a build system.
+We use [Buck2](https://buck2.build/) as the primary build system. The repo also contains generated Ninja files for lightweight smoke builds and Bazel metadata for targets that have `BUILD` files.
 
 Freely distributed under MIT licence.
 
@@ -25,6 +25,7 @@ Make sure `~/.local/bin` is on your `PATH`, then build any project with:
 ./r.sh Normal           # builds and runs //eulerNormal/...
 ./b.sh advent/2020/1    # builds //advent/2020/1/...
 ./bETFModelingBuck2.sh   # builds //ETFModeling:ETFModeling with Buck2
+./bBazel.sh //advent/2024/1:all  # builds an existing Bazel target
 ```
 
 The `cCommon.sh` helper requires `buck2` on PATH. You can install only Buck2
@@ -39,6 +40,10 @@ powershell -ExecutionPolicy Bypass -File .\\installBuck2Windows.ps1
 You can also override the binary with `BUCK_BIN=/path/to/buck2`. Legacy Buck is
 retired for this repository.
 
+Bazel is also available for the subset of the repository that has `BUILD` files.
+Use `./bBazel.sh <target>` or call `bazel build <target>` directly. You can set
+`BAZEL_BIN=/path/to/bazel` to choose a specific Bazel/Bazelisk binary.
+
 ## Building on macOS
 
 The same `b.sh` / `r.sh` scripts work on macOS once `buck2` is on PATH (e.g.
@@ -48,6 +53,6 @@ PATH on macOS and `g++`/`clang` on Linux.
 
 ## Continuous integration
 
-The `.github/workflows/ubuntu-buck2.yml` workflow runs on every push and PR.
-It installs the Ubuntu dependency lists, downloads Buck2, and smoke-tests the
-build on `ubuntu-latest`.
+The `.github/workflows/ubuntu-buck2.yml` and `.github/workflows/ubuntu-ninja.yml`
+workflows run on every push and PR. They install the Ubuntu dependency lists,
+download Buck2 where needed, and smoke-test the build on `ubuntu-latest`.

--- a/bBazel.sh
+++ b/bBazel.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pushd "$(pwd)" >/dev/null
+cd "$(dirname "$0")"
+
+BAZEL_BIN=${BAZEL_BIN:-}
+if [ -z "${BAZEL_BIN}" ]; then
+    if command -v bazel >/dev/null 2>&1; then
+        BAZEL_BIN=$(command -v bazel)
+    elif command -v bazelisk >/dev/null 2>&1; then
+        BAZEL_BIN=$(command -v bazelisk)
+    else
+        echo "ERROR: neither bazel nor bazelisk was found in PATH. Install Bazel or set BAZEL_BIN=/path/to/bazel." >&2
+        exit 1
+    fi
+fi
+
+if [ "$#" -eq 0 ]; then
+    cat >&2 <<'USAGE'
+Usage:
+  ./bBazel.sh <bazel target> [extra bazel args...]
+
+Examples:
+  ./bBazel.sh //advent/2024/1:all
+  ./bBazel.sh //ETFModeling:ETFModeling2
+
+Bazel metadata exists for a subset of this repository. Prefer Buck2 for the
+main build and Ninja for CI smoke builds.
+USAGE
+    exit 2
+fi
+
+exec "${BAZEL_BIN}" build "$@"


### PR DESCRIPTION
## Summary
- document Bazel alongside Buck2 and Ninja as an existing build option for packages with `BUILD` files
- add `bBazel.sh`, a small wrapper around Bazel/Bazelisk with target examples
- update Claude/Pi agent docs with Bazel validation guidance
- ignore Bazel output symlinks/directories

## Testing
- `bash -n bBazel.sh`
- `./bBazel.sh` usage path exits with code 2 as expected
- attempted local `bazel query //advent/2020/1:all`, but this machine's Bazel daemon failed before repo evaluation with `daemonize didn't exit cleanly`
