### PR TITLE
Fix Ubuntu Buck2 installer path

### DIFF
--- a/.github/workflows/ubuntu-buck2.yml
+++ b/.github/workflows/ubuntu-buck2.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Buck2
         run: |
-          ./installBuck2Ubuntu.sh
+          ./scripts/installBuck2Ubuntu.sh
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
 
       - name: Show buck2 version

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The `cCommon.sh` helper requires `buck2` on PATH. You can install only Buck2
 with one of the platform installers:
 
 ```sh
-./installBuck2Ubuntu.sh      # Ubuntu Linux
-./installBuck2MacOS.sh       # macOS
-powershell -ExecutionPolicy Bypass -File .\\installBuck2Windows.ps1
+./scripts/installBuck2Ubuntu.sh      # Ubuntu Linux
+./scripts/installBuck2MacOS.sh       # macOS
+powershell -ExecutionPolicy Bypass -File .\\scripts\\installBuck2Windows.ps1
 ```
 
 You can also override the binary with `BUCK_BIN=/path/to/buck2`. Legacy Buck is

--- a/scripts/installBuck2MacOS.sh
+++ b/scripts/installBuck2MacOS.sh
@@ -3,8 +3,8 @@
 # Install the latest Buck2 release on macOS.
 #
 # Usage:
-#   ./installBuck2MacOS.sh
-#   PREFIX=/usr/local ./installBuck2MacOS.sh
+#   ./scripts/installBuck2MacOS.sh
+#   PREFIX=/usr/local ./scripts/installBuck2MacOS.sh
 #
 # Installs buck2 to ${PREFIX:-$HOME/.local}/bin/buck2.
 

--- a/scripts/installBuck2Ubuntu.sh
+++ b/scripts/installBuck2Ubuntu.sh
@@ -3,8 +3,8 @@
 # Install the latest Buck2 release on Ubuntu Linux.
 #
 # Usage:
-#   ./installBuck2Ubuntu.sh
-#   PREFIX=/usr/local ./installBuck2Ubuntu.sh
+#   ./scripts/installBuck2Ubuntu.sh
+#   PREFIX=/usr/local ./scripts/installBuck2Ubuntu.sh
 #
 # Installs buck2 to ${PREFIX:-$HOME/.local}/bin/buck2.
 

--- a/scripts/installBuck2Windows.ps1
+++ b/scripts/installBuck2Windows.ps1
@@ -2,8 +2,8 @@
 Install the latest Buck2 release on Windows.
 
 Usage:
-  powershell -ExecutionPolicy Bypass -File .\installBuck2Windows.ps1
-  powershell -ExecutionPolicy Bypass -File .\installBuck2Windows.ps1 -InstallDir C:\Tools\Buck2
+  powershell -ExecutionPolicy Bypass -File .\scripts\installBuck2Windows.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\installBuck2Windows.ps1 -InstallDir C:\Tools\Buck2
 
 Installs buck2.exe to $InstallDir, defaulting to $env:USERPROFILE\.local\bin.
 Requires zstd.exe on PATH because Buck2 release assets are distributed as .zst.

--- a/setupUbuntu.sh
+++ b/setupUbuntu.sh
@@ -85,7 +85,7 @@ echo ">>> Installing Buck2"
 if command -v buck2 >/dev/null 2>&1; then
     echo "buck2 already installed: $(command -v buck2)"
 else
-    ./installBuck2Ubuntu.sh
+    ./scripts/installBuck2Ubuntu.sh
 fi
 
 if [[ ":${PATH}:" != *":${HOME}/.local/bin:"* ]]; then


### PR DESCRIPTION
## Summary
- Update the Ubuntu Buck2 CI workflow to call the installer from scripts/ after the installer scripts were moved
- Update setupUbuntu.sh and docs/comments to use the new scripts/ installer paths

## Tests
- git diff --check
- bash -n setupUbuntu.sh scripts/installBuck2Ubuntu.sh scripts/installBuck2MacOS.sh bETFModelingBuck2.sh
- test -x scripts/installBuck2Ubuntu.sh && test -x bETFModelingBuck2.sh