### PR TITLE
Fix bETF Buck2 build on Ubuntu 26.04

### DIFF
--- a/.github/workflows/ubuntu-buck2.yml
+++ b/.github/workflows/ubuntu-buck2.yml
@@ -46,3 +46,16 @@ jobs:
 
       - name: Build ETFModeling with Buck2
         run: ./bETFModelingBuck2.sh
+
+      - name: Build ETFModeling with Buck2 on Ubuntu 26.04
+        run: |
+          docker run --rm -v "${PWD}:/repo" -w /repo ubuntu:26.04 bash -lc '
+            set -euo pipefail
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update
+            apt-get install -y --no-install-recommends \
+              build-essential clang lld curl ca-certificates git pkg-config \
+              python3 python3-pip zstd
+            ./scripts/installBuck2Ubuntu.sh
+            ./bETFModelingBuck2.sh
+          '

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Make sure `~/.local/bin` is on your `PATH`, then build any project with:
 ./bBazel.sh //advent/2024/1:all  # builds an existing Bazel target
 ```
 
-The `cCommon.sh` helper requires `buck2` on PATH. You can install only Buck2
-with one of the platform installers:
+The `cCommon.sh` helper uses `buck2` from PATH, `BUCK_BIN`, or the standard
+`~/.local/bin/buck2` location used by `setupUbuntu.sh`. You can install only
+Buck2 with one of the platform installers:
 
 ```sh
 ./scripts/installBuck2Ubuntu.sh      # Ubuntu Linux

--- a/cCommon.sh
+++ b/cCommon.sh
@@ -7,8 +7,13 @@ if [ -n "${BUCK_BIN:-}" ]; then
     buck_bin="${BUCK_BIN}"
 elif command -v buck2 >/dev/null 2>&1; then
     buck_bin=`command -v buck2`
+elif [ -x "${HOME}/.local/bin/buck2" ]; then
+    # setupUbuntu.sh installs Buck2 here. Ubuntu login shells do not always
+    # pick up ~/.local/bin immediately, so make local builds work without
+    # requiring users to restart their shell or export PATH manually.
+    buck_bin="${HOME}/.local/bin/buck2"
 else
-    echo "ERROR: buck2 not found in PATH. Install Buck2 or set BUCK_BIN=/path/to/buck2." >&2
+    echo "ERROR: buck2 not found. Install Buck2, add ~/.local/bin to PATH, or set BUCK_BIN=/path/to/buck2." >&2
     exit 1
 fi
 if [ "`basename "${buck_bin}"`" = "buck" ]; then


### PR DESCRIPTION
## Summary
- Teach cCommon.sh to find Buck2 at ~/.local/bin/buck2, the location used by setupUbuntu.sh, even when the current shell PATH has not picked it up yet
- Add an Ubuntu 26.04 container smoke build for ./bETFModelingBuck2.sh so this path stays covered
- Update README wording for Buck2 lookup behavior

## Tests
- git diff --check
- bash -n cCommon.sh bETFModelingBuck2.sh setupUbuntu.sh scripts/installBuck2Ubuntu.sh
- podman run --rm --platform linux/amd64 -v "/Users/den.raskovalov/Programming/project-euler:/repo" -w /repo ubuntu:26.04 bash -lc 'set -euo pipefail; export DEBIAN_FRONTEND=noninteractive; apt-get update >/dev/null; apt-get install -y --no-install-recommends build-essential clang lld curl ca-certificates git pkg-config python3 python3-pip zstd >/dev/null; ./scripts/installBuck2Ubuntu.sh >/dev/null; ./bETFModelingBuck2.sh'