### PR TITLE
Add fast Pi via Gauss-Legendre (AGM) + BigFloat sqrt

### DIFF
--- a/bignum/bigfloat.h
+++ b/bignum/bigfloat.h
@@ -89,6 +89,26 @@ class BigFloat {
     return result.round_to_significant(digits);
   }
 
+  // Square root to `digits` significant decimal digits. Throws for negatives.
+  // Computed exactly via integer sqrt of a scaled significand:
+  //   sqrt(sig * 10^e) = isqrt(sig * 10^(e + 2P)) * 10^-P
+  static BigFloat sqrt(const BigFloat& x, int digits = kDefaultDivPrecision) {
+    if (x.sign() < 0) throw std::domain_error("BigFloat::sqrt of negative");
+    if (x.is_zero()) return BigFloat();
+    if (digits < 1) digits = 1;
+    long long P = static_cast<long long>(digits) + 5;  // guard digits
+    long long shift = x.exp_ + 2 * P;
+    BigInt scaled = x.sig_;
+    if (shift >= 0) {
+      scaled *= BigInt::pow10(static_cast<unsigned>(shift));
+    } else {
+      scaled = BigInt::divmod(scaled, BigInt::pow10(static_cast<unsigned>(-shift))).first;
+    }
+    BigFloat result(scaled.isqrt(), -P);
+    result.trim();
+    return result.round_to_significant(digits);
+  }
+
   // --- Comparison -----------------------------------------------------------
   int compare(const BigFloat& o) const {
     if (sign() != o.sign()) return sign() < o.sign() ? -1 : 1;

--- a/bignum/bigint.h
+++ b/bignum/bigint.h
@@ -48,6 +48,24 @@ class BigInt {
     return r;
   }
 
+  // Integer square root: floor(sqrt(*this)). Throws for negative values.
+  // Uses Newton's method seeded with 2^ceil(bits/2) so it converges in
+  // O(log(bits)) iterations.
+  BigInt isqrt() const {
+    if (is_negative()) throw std::domain_error("BigInt::isqrt of negative");
+    if (is_zero()) return BigInt();
+    size_t bits = bit_length(mag_);
+    BigInt x = pow(BigInt(2), (bits + 1) / 2);  // guess >= sqrt(n)
+    const BigInt two(2);
+    while (true) {
+      BigInt y = (x + *this / x) / two;
+      if (y >= x) break;  // monotonically decreasing until floor reached
+      x = std::move(y);
+    }
+    while (x * x > *this) x -= one();  // guard against overshoot
+    return x;
+  }
+
   // base^exp (exponentiation by squaring).
   static BigInt pow(BigInt base, unsigned long long exp) {
     BigInt result(1);

--- a/bignum/tests/tests.cpp
+++ b/bignum/tests/tests.cpp
@@ -40,6 +40,32 @@ BigFloat ComputePi(int digits) {
   return BigFloat(pi_scaled, -(static_cast<long long>(digits) + guard));
 }
 
+// Compute pi to `digits` decimal places using the Gauss-Legendre (AGM)
+// algorithm. Each iteration roughly doubles the number of correct digits
+// (quadratic convergence), so ~log2(digits) iterations suffice.
+BigFloat ComputePiGaussLegendre(int digits) {
+  const int work = digits + 10;  // guard digits
+  BigFloat a(1);
+  BigFloat b = BigFloat::sqrt(BigFloat::divide(BigFloat(1), BigFloat(2), work), work);
+  BigFloat t = BigFloat::divide(BigFloat(1), BigFloat(4), work);
+  BigFloat p(1);
+
+  // log2(digits) + a couple of safety iterations.
+  int iters = 2;
+  for (int v = digits; v > 0; v >>= 1) ++iters;
+  for (int i = 0; i < iters; ++i) {
+    BigFloat a_next = BigFloat::divide(a + b, BigFloat(2), work);
+    BigFloat b_next = BigFloat::sqrt(a * b, work);
+    BigFloat diff = a - a_next;
+    t = t - p * (diff * diff);
+    a = a_next;
+    b = b_next;
+    p = p * BigFloat(2);
+  }
+  BigFloat num = (a + b) * (a + b);
+  return BigFloat::divide(num, BigFloat(4) * t, digits + 2);
+}
+
 }  // namespace
 
 // ===========================================================================
@@ -347,4 +373,39 @@ TEST(Pi, Machin1000DigitsSpotCheck) {
   // Digits 991..1000 (after the decimal point) are "2164201989".
   ASSERT_GE(s.size(), 1002u);  // "3." + at least 1000 digits
   EXPECT_EQ(s.substr(2 + 990, 10), "2164201989");
+}
+
+TEST(BigInt, IntegerSqrt) {
+  EXPECT_EQ(BigInt(0).isqrt().to_string(), "0");
+  EXPECT_EQ(BigInt(1).isqrt().to_string(), "1");
+  EXPECT_EQ(BigInt(15).isqrt().to_string(), "3");
+  EXPECT_EQ(BigInt(16).isqrt().to_string(), "4");
+  EXPECT_EQ(BigInt("1000000000000000000000000").isqrt().to_string(),
+            "1000000000000");
+  BigInt n = BigInt::pow10(100) * BigInt(2);  // 2e100
+  BigInt r = n.isqrt();
+  EXPECT_TRUE(r * r <= n);
+  EXPECT_TRUE((r + BigInt(1)) * (r + BigInt(1)) > n);
+  EXPECT_THROW(BigInt(-4).isqrt(), std::domain_error);
+}
+
+TEST(BigFloat, Sqrt) {
+  EXPECT_EQ(BigFloat::sqrt(BigFloat("4"), 20).to_string().substr(0, 1), "2");
+  EXPECT_EQ(BigFloat::sqrt(BigFloat("2"), 30).to_string().substr(0, 17),
+            "1.414213562373095");
+  EXPECT_EQ(BigFloat::sqrt(BigFloat("0"), 10).to_string(), "0");
+  EXPECT_EQ(BigFloat::sqrt(BigFloat("0.25"), 10).to_string(), "0.5");
+  EXPECT_THROW(BigFloat::sqrt(BigFloat("-1"), 10), std::domain_error);
+}
+
+// Gauss-Legendre (AGM) is quadratically convergent: it roughly doubles the
+// number of correct digits each iteration, far fewer iterations than Machin.
+TEST(Pi, GaussLegendre100Digits) {
+  const std::string kPi100 =
+      "3."
+      "1415926535897932384626433832795028841971"
+      "6939937510582097494459230781640628620899"
+      "86280348253421170679";
+  BigFloat pi = ComputePiGaussLegendre(100);
+  EXPECT_EQ(pi.to_string().substr(0, 102), kPi100);
 }


### PR DESCRIPTION
## Summary

A second, **faster** way to generate a long value of π — the **Gauss–Legendre (AGM)** algorithm, which converges *quadratically* (it roughly doubles the number of correct digits every iteration, so π to 100 digits needs only ~9 iterations).

This required two new building blocks in the library:

- **`BigInt::isqrt()`** — integer floor square root via Newton's method, seeded with `2^ceil(bits/2)` for O(log bits) convergence.
- **`BigFloat::sqrt(x, digits)`** — decimal square root to N significant digits, computed exactly as `isqrt(sig · 10^(e+2P)) · 10^-P` (no floating-point Newton needed).

## Tests
- `BigInt.IntegerSqrt` — exact/floor behavior, large values, negative throws.
- `BigFloat.Sqrt` — √2, √4, √0.25, zero, negative throws.
- `Pi.GaussLegendre100Digits` — π to 100 places, verified against the known constant (runs in a few ms).

All **39 tests pass** (Ninja + Buck2).

> Note: base is `add-bignum-library` (PR #18) since the bignum library isn't on `master` yet — this keeps the diff incremental. Retarget to `master` once #18 merges.