### PR TITLE
Move Pi tests into a dedicated pi_test.cpp

### DIFF
--- a/bignum/tests/BUCK
+++ b/bignum/tests/BUCK
@@ -10,6 +10,17 @@ cxx_binary(
 )
 
 cxx_binary(
+    name="piTest",
+    srcs=[
+        "pi_test.cpp",
+    ],
+    deps=[
+        "//bignum:bignum",
+        "//gtest:gtest",
+    ],
+)
+
+cxx_binary(
     name="cpuCrossCheckTest",
     srcs=[
         "cpu_crosscheck_test.cpp",

--- a/bignum/tests/build.ninja
+++ b/bignum/tests/build.ninja
@@ -4,6 +4,10 @@ build $builddir/obj/bignum/tests/tests.cpp.o: cxx bignum/tests/tests.cpp
 build $builddir/bin/bignum/tests/bignumTest: link $builddir/obj/bignum/tests/tests.cpp.o $builddir/lib/gtest/gtest.a $builddir/lib/gtest/gtestInt.a
 build bignum/tests/bignumTest: phony $builddir/bin/bignum/tests/bignumTest
 
+build $builddir/obj/bignum/tests/pi_test.cpp.o: cxx bignum/tests/pi_test.cpp
+build $builddir/bin/bignum/tests/piTest: link $builddir/obj/bignum/tests/pi_test.cpp.o $builddir/lib/gtest/gtest.a $builddir/lib/gtest/gtestInt.a
+build bignum/tests/piTest: phony $builddir/bin/bignum/tests/piTest
+
 build $builddir/obj/bignum/tests/cpu_crosscheck_test.cpp.o: cxx bignum/tests/cpu_crosscheck_test.cpp
 build $builddir/bin/bignum/tests/cpuCrossCheckTest: link $builddir/obj/bignum/tests/cpu_crosscheck_test.cpp.o $builddir/lib/gtest/gtest.a $builddir/lib/gtest/gtestInt.a
 build bignum/tests/cpuCrossCheckTest: phony $builddir/bin/bignum/tests/cpuCrossCheckTest

--- a/bignum/tests/pi_test.cpp
+++ b/bignum/tests/pi_test.cpp
@@ -1,0 +1,108 @@
+// Tests that generate a long value of Pi using fast mathematical algorithms
+// and verify the digits against the known constant.
+//
+//   * Machin's formula        pi = 16*arctan(1/5) - 4*arctan(1/239)
+//   * Gauss-Legendre (AGM)    quadratically convergent
+#include <string>
+
+#include "bignum/bigint.h"
+#include "bignum/bigfloat.h"
+
+#include "gtest/gtest.h"
+
+using bignum::BigInt;
+using bignum::BigFloat;
+
+namespace {
+
+// Fixed-point arctan(1/x) scaled by `scale`, i.e. returns round(scale*atan(1/x)).
+// Uses the Taylor series atan(1/x) = sum_{k>=0} (-1)^k / ((2k+1) * x^(2k+1)),
+// which converges quickly for large x (e.g. x = 5 and x = 239 in Machin's
+// formula). All arithmetic is integer-only via BigInt.
+BigInt ScaledArctanInv(long long x, const BigInt& scale) {
+  BigInt x2(x * x);
+  BigInt power = scale / BigInt(x);  // scale / x  (k = 0 term)
+  BigInt sum = power;
+  for (long long k = 1;; ++k) {
+    power /= x2;  // scale / x^(2k+1)
+    BigInt term = power / BigInt(2 * k + 1);
+    if (term.is_zero()) break;
+    if (k & 1) sum -= term; else sum += term;
+  }
+  return sum;
+}
+
+// Compute pi to `digits` decimal places using Machin's formula:
+//   pi = 16*arctan(1/5) - 4*arctan(1/239)
+// A handful of guard digits are used internally and then trimmed.
+BigFloat ComputePiMachin(int digits) {
+  const int guard = 12;
+  BigInt scale = BigInt::pow10(static_cast<unsigned>(digits + guard));
+  BigInt pi_scaled =
+      BigInt(16) * ScaledArctanInv(5, scale) - BigInt(4) * ScaledArctanInv(239, scale);
+  return BigFloat(pi_scaled, -(static_cast<long long>(digits) + guard));
+}
+
+// Compute pi to `digits` decimal places using the Gauss-Legendre (AGM)
+// algorithm. Each iteration roughly doubles the number of correct digits
+// (quadratic convergence), so ~log2(digits) iterations suffice.
+BigFloat ComputePiGaussLegendre(int digits) {
+  const int work = digits + 10;  // guard digits
+  BigFloat a(1);
+  BigFloat b = BigFloat::sqrt(BigFloat::divide(BigFloat(1), BigFloat(2), work), work);
+  BigFloat t = BigFloat::divide(BigFloat(1), BigFloat(4), work);
+  BigFloat p(1);
+
+  // log2(digits) + a couple of safety iterations.
+  int iters = 2;
+  for (int v = digits; v > 0; v >>= 1) ++iters;
+  for (int i = 0; i < iters; ++i) {
+    BigFloat a_next = BigFloat::divide(a + b, BigFloat(2), work);
+    BigFloat b_next = BigFloat::sqrt(a * b, work);
+    BigFloat diff = a - a_next;
+    t = t - p * (diff * diff);
+    a = a_next;
+    b = b_next;
+    p = p * BigFloat(2);
+  }
+  BigFloat num = (a + b) * (a + b);
+  return BigFloat::divide(num, BigFloat(4) * t, digits + 2);
+}
+
+// Pi to 100 decimal places (reference constant), as "3." + 100 fractional
+// digits (102 characters total).
+const char* const kPi100 =
+    "3."
+    "1415926535897932384626433832795028841971"
+    "6939937510582097494459230781640628620899"
+    "86280348253421170679";
+
+}  // namespace
+
+TEST(Pi, Machin100Digits) {
+  BigFloat pi = ComputePiMachin(100);
+  EXPECT_EQ(pi.to_string().substr(0, 102), kPi100);
+}
+
+TEST(Pi, Machin1000DigitsSpotCheck) {
+  BigFloat pi = ComputePiMachin(1000);
+  std::string s = pi.to_string();
+  EXPECT_EQ(s.substr(0, 12), "3.1415926535");
+  // Pi to 1000 decimal places famously ends with "...2164201989".
+  // Digits 991..1000 (after the decimal point) are "2164201989".
+  ASSERT_GE(s.size(), 1002u);  // "3." + at least 1000 digits
+  EXPECT_EQ(s.substr(2 + 990, 10), "2164201989");
+}
+
+// Gauss-Legendre (AGM) is quadratically convergent: it roughly doubles the
+// number of correct digits each iteration, far fewer iterations than Machin.
+TEST(Pi, GaussLegendre100Digits) {
+  BigFloat pi = ComputePiGaussLegendre(100);
+  EXPECT_EQ(pi.to_string().substr(0, 102), kPi100);
+}
+
+// Both algorithms must agree with each other to 100 digits.
+TEST(Pi, MachinAndGaussLegendreAgree) {
+  EXPECT_EQ(ComputePiMachin(100).to_string().substr(0, 102),
+            ComputePiGaussLegendre(100).to_string().substr(0, 102));
+}

--- a/bignum/tests/tests.cpp
+++ b/bignum/tests/tests.cpp
@@ -10,63 +10,7 @@
 using bignum::BigInt;
 using bignum::BigFloat;
 
-namespace {
-
-// Fixed-point arctan(1/x) scaled by `scale`, i.e. returns round(scale*atan(1/x)).
-// Uses the Taylor series atan(1/x) = sum_{k>=0} (-1)^k / ((2k+1) * x^(2k+1)),
-// which converges quickly for large x (e.g. x = 5 and x = 239 in Machin's
-// formula). All arithmetic is integer-only via BigInt.
-BigInt ScaledArctanInv(long long x, const BigInt& scale) {
-  BigInt x2(x * x);
-  BigInt power = scale / BigInt(x);  // scale / x  (k = 0 term)
-  BigInt sum = power;
-  for (long long k = 1;; ++k) {
-    power /= x2;  // scale / x^(2k+1)
-    BigInt term = power / BigInt(2 * k + 1);
-    if (term.is_zero()) break;
-    if (k & 1) sum -= term; else sum += term;
-  }
-  return sum;
-}
-
-// Compute pi to `digits` decimal places using Machin's formula:
-//   pi = 16*arctan(1/5) - 4*arctan(1/239)
-// A handful of guard digits are used internally and then trimmed.
-BigFloat ComputePi(int digits) {
-  const int guard = 12;
-  BigInt scale = BigInt::pow10(static_cast<unsigned>(digits + guard));
-  BigInt pi_scaled =
-      BigInt(16) * ScaledArctanInv(5, scale) - BigInt(4) * ScaledArctanInv(239, scale);
-  return BigFloat(pi_scaled, -(static_cast<long long>(digits) + guard));
-}
-
-// Compute pi to `digits` decimal places using the Gauss-Legendre (AGM)
-// algorithm. Each iteration roughly doubles the number of correct digits
-// (quadratic convergence), so ~log2(digits) iterations suffice.
-BigFloat ComputePiGaussLegendre(int digits) {
-  const int work = digits + 10;  // guard digits
-  BigFloat a(1);
-  BigFloat b = BigFloat::sqrt(BigFloat::divide(BigFloat(1), BigFloat(2), work), work);
-  BigFloat t = BigFloat::divide(BigFloat(1), BigFloat(4), work);
-  BigFloat p(1);
-
-  // log2(digits) + a couple of safety iterations.
-  int iters = 2;
-  for (int v = digits; v > 0; v >>= 1) ++iters;
-  for (int i = 0; i < iters; ++i) {
-    BigFloat a_next = BigFloat::divide(a + b, BigFloat(2), work);
-    BigFloat b_next = BigFloat::sqrt(a * b, work);
-    BigFloat diff = a - a_next;
-    t = t - p * (diff * diff);
-    a = a_next;
-    b = b_next;
-    p = p * BigFloat(2);
-  }
-  BigFloat num = (a + b) * (a + b);
-  return BigFloat::divide(num, BigFloat(4) * t, digits + 2);
-}
-
-}  // namespace
+// Note: the Pi-generation tests live in bignum/tests/pi_test.cpp.
 
 // ===========================================================================
 // BigInt
@@ -348,32 +292,8 @@ TEST(BigFloat, StreamRoundTrip) {
 }
 
 // ===========================================================================
-// Fun: compute a long value of Pi with a fast algorithm (Machin's formula)
+// Square roots (building blocks used by the Pi tests in pi_test.cpp)
 // ===========================================================================
-
-TEST(Pi, Machin100Digits) {
-  // Reference: pi to 100 decimal places.
-  const std::string kPi100 =
-      "3."
-      "1415926535897932384626433832795028841971"
-      "6939937510582097494459230781640628620899"
-      "86280348253421170679";
-
-  BigFloat pi = ComputePi(100);
-  std::string s = pi.to_string();
-  // Compare "3." + 100 fractional digits (102 characters).
-  EXPECT_EQ(s.substr(0, 102), kPi100);
-}
-
-TEST(Pi, Machin1000DigitsSpotCheck) {
-  BigFloat pi = ComputePi(1000);
-  std::string s = pi.to_string();
-  EXPECT_EQ(s.substr(0, 12), "3.1415926535");
-  // Pi to 1000 decimal places famously ends with "...2164201989".
-  // Digits 991..1000 (after the decimal point) are "2164201989".
-  ASSERT_GE(s.size(), 1002u);  // "3." + at least 1000 digits
-  EXPECT_EQ(s.substr(2 + 990, 10), "2164201989");
-}
 
 TEST(BigInt, IntegerSqrt) {
   EXPECT_EQ(BigInt(0).isqrt().to_string(), "0");
@@ -396,16 +316,4 @@ TEST(BigFloat, Sqrt) {
   EXPECT_EQ(BigFloat::sqrt(BigFloat("0"), 10).to_string(), "0");
   EXPECT_EQ(BigFloat::sqrt(BigFloat("0.25"), 10).to_string(), "0.5");
   EXPECT_THROW(BigFloat::sqrt(BigFloat("-1"), 10), std::domain_error);
-}
-
-// Gauss-Legendre (AGM) is quadratically convergent: it roughly doubles the
-// number of correct digits each iteration, far fewer iterations than Machin.
-TEST(Pi, GaussLegendre100Digits) {
-  const std::string kPi100 =
-      "3."
-      "1415926535897932384626433832795028841971"
-      "6939937510582097494459230781640628620899"
-      "86280348253421170679";
-  BigFloat pi = ComputePiGaussLegendre(100);
-  EXPECT_EQ(pi.to_string().substr(0, 102), kPi100);
 }


### PR DESCRIPTION
## Summary

Reorganizes the test suite by moving the Pi-generation tests out of the catch-all `tests.cpp` into a dedicated file **`bignum/tests/pi_test.cpp`** (new target `//bignum/tests:piTest`).

### Moved into `pi_test.cpp`
- Helpers: `ScaledArctanInv`, `ComputePiMachin` (renamed from `ComputePi`), `ComputePiGaussLegendre`, and the shared `kPi100` reference constant.
- Tests: `Pi.Machin100Digits`, `Pi.Machin1000DigitsSpotCheck`, `Pi.GaussLegendre100Digits`.
- Added `Pi.MachinAndGaussLegendreAgree` — checks both algorithms match to 100 digits.

### Stays in `tests.cpp`
- The `BigInt.IntegerSqrt` / `BigFloat.Sqrt` building-block tests (with an updated section comment pointing at `pi_test.cpp`).

Pure test reorganization — no library/behavior change.

## Testing
```
ninja bignum/tests/piTest bignum/tests/bignumTest
./build-ninja/bin/bignum/tests/piTest        # 4 Pi tests pass
./build-ninja/bin/bignum/tests/bignumTest    # 36 tests pass
buck2 build //bignum/tests:piTest //bignum/tests:bignumTest   # ok
```

> Base is `bignum-cpu-crosscheck` (PR #20) to keep the stack incremental.